### PR TITLE
Drop "behavior" from enhancer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Enhance your history object with one of the scroll behaviors in this library to 
 
 ```js
 import createHistory from 'history/lib/createBrowserHistory'
-import useScrollBehavior from 'scroll-behavior/lib/useStandardScrollBehavior'
+import useScroll from 'scroll-behavior/lib/useStandardScroll'
 
-const history = useScrollBehavior(createHistory)()
+const history = useScroll(createHistory)()
 ```
 
 ## Guide
@@ -29,18 +29,18 @@ You may also want to install [React Router](https://github.com/rackt/react-route
 
 ### Scroll behaviors
 
-#### `useScrollToTopBehavior`
+#### `useScrollToTop`
 
-`useScrollToTopBehavior` scrolls to the top of the page after any transition.
+`useScrollToTop` scrolls to the top of the page after any transition.
 
 This is not fully reliable for `POP` transitions.
 
-#### `useSimpleScrollBehavior`
+#### `useSimpleScroll`
 
-`useSimpleScrollBehavior` scrolls to the top of the page on `PUSH` and `REPLACE` transitions, while allowing the browser to manage scroll position for `POP` transitions.
+`useSimpleScroll` scrolls to the top of the page on `PUSH` and `REPLACE` transitions, while allowing the browser to manage scroll position for `POP` transitions.
 
 This can give pretty good results with synchronous transitions on browsers like Chrome that don't update the scroll position until after they've notified `history` of the location change. It will not work as well when using asynchronous transitions or with browsers like Firefox that update the scroll position before emitting the location change.
 
-#### `useStandardScrollBehavior`
+#### `useStandardScroll`
 
-`useStandardScrollBehavior` attempts to imitate native browser scroll behavior by recording updates to the window scroll position, then restoring the previous scroll position upon a `POP` transition.
+`useStandardScroll` attempts to imitate native browser scroll behavior by recording updates to the window scroll position, then restoring the previous scroll position upon a `POP` transition.

--- a/modules/__tests__/trivial-test.js
+++ b/modules/__tests__/trivial-test.js
@@ -1,7 +1,7 @@
 import '..'
-import '../useScrollToTopBehavior'
-import '../useSimpleScrollBehavior'
-import '../useStandardScrollBehavior'
+import '../useScrollToTop'
+import '../useSimpleScroll'
+import '../useStandardScroll'
 
 describe('trivial test', () => {
   it('should successfully load all the modules', () => {})

--- a/modules/index.js
+++ b/modules/index.js
@@ -1,6 +1,6 @@
 // This is just for convenience; users should import the specific behavior
 // directly from `lib/`.
 
-export useScrollToTopBehavior from './useScrollToTopBehavior'
-export useSimpleScrollBehavior from './useSimpleScrollBehavior'
-export useStandardScrollBehavior from './useStandardScrollBehavior'
+export useScrollToTop from './useScrollToTop'
+export useSimpleScroll from './useSimpleScroll'
+export useStandardScroll from './useStandardScroll'

--- a/modules/useScrollToTop.js
+++ b/modules/useScrollToTop.js
@@ -1,12 +1,11 @@
 import scrollTo from './utils/scrollTo'
 
 /**
- * `useScrollToTopBehavior` scrolls to the top of the page after any
- * transition.
+ * `useScrollToTop` scrolls to the top of the page after any transition.
  *
  * This is not fully reliable for `POP` transitions.
  */
-export default function useScrollToTopBehavior(createHistory) {
+export default function useScrollToTop(createHistory) {
   return options => {
     const history = createHistory(options)
 

--- a/modules/useSimpleScroll.js
+++ b/modules/useSimpleScroll.js
@@ -3,9 +3,9 @@ import { POP } from 'history/lib/Actions'
 import scrollTo from './utils/scrollTo'
 
 /**
- * `useSimpleScrollBehavior` scrolls to the top of the page on `PUSH` and
- * `REPLACE` transitions, while allowing the browser to manage scroll position
- * for `POP` transitions.
+ * `useSimpleScroll` scrolls to the top of the page on `PUSH` and `REPLACE`
+ * transitions, while allowing the browser to manage scroll position for `POP`
+ * transitions.
  *
  * This can give pretty good results with synchronous transitions on browsers
  * like Chrome that don't update the scroll position until after they've
@@ -13,7 +13,7 @@ import scrollTo from './utils/scrollTo'
  * using asynchronous transitions or with browsers like Firefox that update
  * the scroll position before emitting the location change.
  */
-export default function useSimpleScrollBehavior(createHistory) {
+export default function useSimpleScroll(createHistory) {
   return options => {
     const history = createHistory(options)
 

--- a/modules/useStandardScroll.js
+++ b/modules/useStandardScroll.js
@@ -7,11 +7,11 @@ import { readState, saveState } from 'history/lib/DOMStateStorage'
 import scrollTo from './utils/scrollTo'
 
 /**
- * `useStandardScrollBehavior` attempts to imitate native browser scroll
- * behavior by recording updates to the window scroll position, then restoring
- * the previous scroll position upon a `POP` transition.
+ * `useStandardScroll` attempts to imitate native browser scroll behavior by
+ * recording updates to the window scroll position, then restoring the previous
+ * scroll position upon a `POP` transition.
  */
-export default function useStandardScrollBehavior(createHistory) {
+export default function useStandardScroll(createHistory) {
   return options => {
     const history = createHistory(options)
 


### PR DESCRIPTION
Per @knowbody ... pity "scroll" wasn't free on npm, though.